### PR TITLE
fix: prevent data races and panics in SDK stop/heartbeat handling

### DIFF
--- a/go/preflight_kit_sdk/CHANGELOG.md
+++ b/go/preflight_kit_sdk/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix: prevent data races and panics in the preflight stop/heartbeat handling — guard the shared `stopEvents` slice with a mutex, make `heartbeat.Monitor.Stop` idempotent, and make `RecordHeartbeat` a non-blocking, closed-safe send, so concurrent stop/status/timeout paths can no longer crash the extension (double-close / send-on-closed-channel / slice race)
+- fix: stop and replace an existing heartbeat monitor when a preflight is started again for the same execution id, instead of leaking the previous monitor's goroutines
 
 ## 2.0.2
 

--- a/go/preflight_kit_sdk/CHANGELOG.md
+++ b/go/preflight_kit_sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: prevent data races and panics in the preflight stop/heartbeat handling — guard the shared `stopEvents` slice with a mutex, make `heartbeat.Monitor.Stop` idempotent, and make `RecordHeartbeat` a non-blocking, closed-safe send, so concurrent stop/status/timeout paths can no longer crash the extension (double-close / send-on-closed-channel / slice race)
+
 ## 2.0.2
 
 - Update dependencies

--- a/go/preflight_kit_sdk/heartbeat/heartbeat.go
+++ b/go/preflight_kit_sdk/heartbeat/heartbeat.go
@@ -5,11 +5,14 @@ package heartbeat
 
 import (
 	"github.com/rs/zerolog/log"
+	"sync"
 	"time"
 )
 
 type Monitor struct {
-	pulse chan time.Time
+	mu     sync.Mutex
+	pulse  chan time.Time
+	closed bool
 }
 
 func Notify(ch chan<- time.Time, interval, timeout time.Duration) *Monitor {
@@ -71,10 +74,29 @@ func Notify(ch chan<- time.Time, interval, timeout time.Duration) *Monitor {
 
 func (h *Monitor) RecordHeartbeat() {
 	log.Trace().Msg("received heartbeat")
-	h.pulse <- time.Now()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
+	// Non-blocking send: once Stop has closed the channel we must not send (that panics),
+	// and if the buffer is full the reader only needs to see recent activity — so dropping
+	// a beat is fine and must never block the caller (an HTTP status handler goroutine).
+	select {
+	case h.pulse <- time.Now():
+	default:
+	}
 }
 
+// Stop is idempotent: concurrent or repeated Stop calls (e.g. the HTTP stop handler and
+// the heartbeat-timeout goroutine both stopping the same execution) close the channel once.
 func (h *Monitor) Stop() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
 	log.Debug().Msg("closing heartbeat channel")
+	h.closed = true
 	close(h.pulse)
 }

--- a/go/preflight_kit_sdk/heartbeat/heartbeat_test.go
+++ b/go/preflight_kit_sdk/heartbeat/heartbeat_test.go
@@ -5,10 +5,34 @@ package heartbeat
 
 import (
 	"github.com/stretchr/testify/assert"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 )
+
+// TestMonitor_concurrent_stop_and_record hammers RecordHeartbeat with concurrent and
+// repeated Stop calls: it must never panic (double close / send on closed channel), and a
+// RecordHeartbeat after Stop must be a no-op. Run under -race.
+func TestMonitor_concurrent_stop_and_record(t *testing.T) {
+	ch := make(chan time.Time, 1)
+	hb := Notify(ch, time.Hour, time.Hour)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); hb.RecordHeartbeat() }()
+	}
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); hb.Stop() }()
+	}
+	wg.Wait()
+
+	// After Stop, further heartbeats are dropped rather than panicking.
+	hb.RecordHeartbeat()
+	hb.Stop()
+}
 
 func TestHeartbeat_should_timeout(t *testing.T) {
 	ch := make(chan time.Time)

--- a/go/preflight_kit_sdk/preflight_sdk.go
+++ b/go/preflight_kit_sdk/preflight_sdk.go
@@ -28,6 +28,7 @@ var (
 	registeredPreflights = make(map[string]interface{})
 	statePersister       = state_persister.NewInmemoryStatePersister()
 	stopEvents           = make([]stopEvent, 0, 10)
+	stopEventsMu         sync.Mutex
 	heartbeatMonitors    = sync.Map{}
 )
 
@@ -225,14 +226,17 @@ func recordHeartbeat(preflightActionExecutionId uuid.UUID) {
 }
 
 func stopMonitorHeartbeat(preflightActionExecutionId uuid.UUID) {
-	monitor, _ := heartbeatMonitors.Load(preflightActionExecutionId)
-	if monitor != nil {
+	// LoadAndDelete so that when two paths stop the same execution concurrently (the HTTP
+	// stop handler and the heartbeat-timeout goroutine) only one gets the monitor; Stop is
+	// idempotent regardless.
+	if monitor, ok := heartbeatMonitors.LoadAndDelete(preflightActionExecutionId); ok {
 		monitor.(*heartbeat.Monitor).Stop()
-		heartbeatMonitors.Delete(preflightActionExecutionId)
 	}
 }
 
 func markAsStopped(preflightActionExecutionId uuid.UUID, reason string) {
+	stopEventsMu.Lock()
+	defer stopEventsMu.Unlock()
 	if len(stopEvents) > 100 {
 		stopEvents = stopEvents[1:]
 	}
@@ -244,6 +248,8 @@ func markAsStopped(preflightActionExecutionId uuid.UUID, reason string) {
 }
 
 func getStopEvent(preflightActionExecutionId uuid.UUID) *stopEvent {
+	stopEventsMu.Lock()
+	defer stopEventsMu.Unlock()
 	for _, event := range stopEvents {
 		if event.preflightActionExecutionId == preflightActionExecutionId {
 			return &event

--- a/go/preflight_kit_sdk/preflight_sdk.go
+++ b/go/preflight_kit_sdk/preflight_sdk.go
@@ -210,7 +210,12 @@ func monitorHeartbeatWithCallback(preflightActionExecutionId uuid.UUID, interval
 	extendedInterval := interval + min(interval/100*5, 500*time.Millisecond)
 	ch := make(chan time.Time, 1)
 	monitor := heartbeat.Notify(ch, extendedInterval, timeout)
-	heartbeatMonitors.Store(preflightActionExecutionId, monitor)
+	// Stop and replace any monitor already registered for this execution so a repeated
+	// Start (same execution id) can't leak the previous monitor's goroutines. Stop is
+	// idempotent, so this is safe even if the previous monitor already stopped.
+	if prev, loaded := heartbeatMonitors.Swap(preflightActionExecutionId, monitor); loaded {
+		prev.(*heartbeat.Monitor).Stop()
+	}
 	go func() {
 		for range ch {
 			callback()

--- a/go/preflight_kit_sdk/preflight_sdk_test.go
+++ b/go/preflight_kit_sdk/preflight_sdk_test.go
@@ -3,10 +3,27 @@ package preflight_kit_sdk
 import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
 )
+
+// TestMonitorHeartbeat_restart_does_not_leak_goroutines verifies that repeatedly starting a
+// heartbeat monitor for the same execution id (e.g. a retried Start) replaces and stops the
+// previous monitor rather than leaking its goroutines. Each monitor spins two goroutines;
+// without the Swap-and-Stop they would accumulate.
+func TestMonitorHeartbeat_restart_does_not_leak_goroutines(t *testing.T) {
+	id := uuid.New()
+	base := runtime.NumGoroutine()
+	for i := 0; i < 50; i++ {
+		monitorHeartbeatWithCallback(id, time.Hour, time.Hour, func() {})
+	}
+	stopMonitorHeartbeat(id)
+	assert.Eventually(t, func() bool {
+		return runtime.NumGoroutine() <= base+4
+	}, 2*time.Second, 20*time.Millisecond, "restarting the monitor must not leak goroutines")
+}
 
 // TestStopEvents_concurrent_access exercises markAsStopped (write) and getStopEvent (read)
 // from many goroutines, mirroring the HTTP stop/status handlers, the heartbeat-timeout

--- a/go/preflight_kit_sdk/preflight_sdk_test.go
+++ b/go/preflight_kit_sdk/preflight_sdk_test.go
@@ -3,9 +3,24 @@ package preflight_kit_sdk
 import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"sync"
 	"testing"
 	"time"
 )
+
+// TestStopEvents_concurrent_access exercises markAsStopped (write) and getStopEvent (read)
+// from many goroutines, mirroring the HTTP stop/status handlers, the heartbeat-timeout
+// goroutine and the signal handler racing on the shared stopEvents slice. Run under -race.
+func TestStopEvents_concurrent_access(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		id := uuid.New()
+		wg.Add(2)
+		go func() { defer wg.Done(); markAsStopped(id, "test") }()
+		go func() { defer wg.Done(); _ = getStopEvent(id) }()
+	}
+	wg.Wait()
+}
 
 // This test reproduced an issue in which new heartbeats
 // would not be processed anymore and led to a cancel the preflight.


### PR DESCRIPTION
## Problem

The kit audit found the preflight SDK carries the **same two concurrency bugs** just fixed in action-kit ([action-kit#457](https://github.com/steadybit/action-kit/pull/457)) — its stop/heartbeat plumbing is a near-verbatim copy — plus a related monitor-goroutine leak. All three can affect any extension using preflights; the first two crash the process (data race / panic in a non-recovered goroutine, not caught by `PanicRecovery`).

1. **`stopEvents` slice data race** (MAJOR) — `markAsStopped` (`append` + `stopEvents[1:]`) and `getStopEvent` (`range`) run with no lock from the HTTP `status`/`cancel` handlers, the heartbeat-timeout goroutine (`CancelPreflight`) and the signal handler.
2. **Heartbeat channel double-close / send-on-closed panic** (HIGH) — `Monitor.Stop` closed `pulse` non-idempotently and `RecordHeartbeat` did a blocking send; two racing stop paths → `close of closed channel`, a concurrent record → `send on closed channel`.
3. **Heartbeat monitor goroutine leak on repeated Start** (MAJOR) — `monitorHeartbeatWithCallback` stored a new monitor under an execution id without stopping any monitor already registered there, leaking the previous monitor's two goroutines on a retried Start.

## Fix

- Guard `stopEvents` with a package `sync.Mutex`.
- Make `heartbeat.Monitor` self-guarding: `mu`+`closed` flag → idempotent `Stop` and a non-blocking, closed-safe `RecordHeartbeat`.
- `stopMonitorHeartbeat` uses `sync.Map.LoadAndDelete`.
- `monitorHeartbeatWithCallback` uses `sync.Map.Swap` to stop-and-replace any existing monitor for the same execution id.

Adds race tests for the stop/heartbeat paths and a goroutine-leak regression test for repeated Start.

## Verification

`go build ./...`, `go vet ./...`, `go test -race ./...` pass (module `go/preflight_kit_sdk`); existing tests still pass.

Fixes (1) and (2) mirror action-kit#457; (3) is the preflight-specific monitor leak. This closes all three preflight-kit findings from the kit audit.
