### PR TITLE
chore: add Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,9 @@
+name: Claude Code Review
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, ready_for_review, reopened]
+jobs:
+  claude-review:
+    uses: steadybit/extension-kit/.github/workflows/reusable-claude-pr-review.yml@main
+    secrets: inherit # NOSONAR


### PR DESCRIPTION
## Summary
- Add the standard `claude-review.yml` workflow (used by all extensions and the other -kit repos) so PRs get automated Claude review.