### PR TITLE
feat(preflight_kit_sdk): bump index revision on register/clear

### DIFF
--- a/go/preflight_kit_sdk/go.mod
+++ b/go/preflight_kit_sdk/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/rs/zerolog v1.35.1
-	github.com/steadybit/extension-kit v1.10.8
+	github.com/steadybit/extension-kit v1.11.0
 	github.com/steadybit/preflight-kit/go/preflight_kit_api v1.4.5
 	github.com/stretchr/testify v1.11.1
 )
@@ -18,7 +18,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.22.5 // indirect
 	github.com/go-openapi/swag/jsonname v0.25.5 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
+	github.com/klauspost/compress v1.19.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/oapi-codegen/runtime v1.4.2 // indirect
@@ -27,7 +27,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
-	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go/preflight_kit_sdk/go.sum
+++ b/go/preflight_kit_sdk/go.sum
@@ -20,8 +20,8 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
-github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
-github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.19.0 h1:sXLILfc9jV2QYWkzFOPWStmcUVH2RHEB1JCdY2oVvCQ=
+github.com/klauspost/compress v1.19.0/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -53,8 +53,8 @@ github.com/rs/zerolog v1.35.1/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
-github.com/steadybit/extension-kit v1.10.8 h1:Xr6YmlbTLpIGsLCkVoGF3o4SPvRLl7X3AgpcKRKiQfA=
-github.com/steadybit/extension-kit v1.10.8/go.mod h1:n1PMz8AwjGvl/M/CWSVjoHCE8qM74Tx+nfC4iiuhEPA=
+github.com/steadybit/extension-kit v1.11.0 h1:sliZpOlZKp0XuPKoH3pNyKzI0Tt3iYDCfwaoga5jriw=
+github.com/steadybit/extension-kit v1.11.0/go.mod h1:Bm3pbDipaVc64zpxfOEL9Shpr5CNd4By2x4/jSSr0bA=
 github.com/steadybit/preflight-kit/go/preflight_kit_api v1.4.5 h1:GortZklQQXqhOqqLd8LU6ZwKIm2ngPSShSuU/VPvv8E=
 github.com/steadybit/preflight-kit/go/preflight_kit_api v1.4.5/go.mod h1:w1L24EJPSUVKHmjVARYJF7Sg4ZuAccCBAghBgqJrbOQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -62,8 +62,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
-golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=
 golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go/preflight_kit_sdk/preflight_sdk.go
+++ b/go/preflight_kit_sdk/preflight_sdk.go
@@ -176,11 +176,13 @@ func RegisterPreflight[T any](a Preflight[T]) {
 	adapter := newPreflightHttpAdapter(a)
 	registeredPreflights[adapter.description.Id] = a
 	adapter.registerHandlers()
+	exthttp.BumpRevision()
 }
 
 // ClearRegisteredPreflights clears all registered preflights - used for testing. Warning: This will not remove the registered routes from the http server.
 func ClearRegisteredPreflights() {
 	registeredPreflights = make(map[string]any)
+	exthttp.BumpRevision()
 }
 
 // GetPreflightList returns a list of all root endpoints of registered preflights.

--- a/go/preflight_kit_sdk/revision_test.go
+++ b/go/preflight_kit_sdk/revision_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+
+package preflight_kit_sdk
+
+import (
+	"testing"
+
+	"github.com/steadybit/extension-kit/exthttp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisterPreflightBumpsRevision(t *testing.T) {
+	ClearRegisteredPreflights()
+	t.Cleanup(ClearRegisteredPreflights)
+
+	before := exthttp.Revision()
+	RegisterPreflight[ExampleState](NewExamplePreflight(make(chan Call, 10)))
+	assert.NotEqual(t, before, exthttp.Revision(), "RegisterPreflight must bump the index revision")
+}
+
+func TestClearRegisteredPreflightsBumpsRevision(t *testing.T) {
+	before := exthttp.Revision()
+	ClearRegisteredPreflights()
+	assert.NotEqual(t, before, exthttp.Revision(), "ClearRegisteredPreflights must bump the index revision")
+}


### PR DESCRIPTION
## What

`RegisterPreflight` and `ClearRegisteredPreflights` now call `exthttp.BumpRevision()` so the extension index ETag reflects the set of registered preflights.

## Why

Part of centralizing index-response caching in the SDKs (see steadybit/extension-kit#158). The index ETag becomes registration-scoped instead of frozen at process start.

## Depends on

steadybit/extension-kit#158 — `exthttp.BumpRevision` is introduced there. **CI on this PR is red until extension-kit is tagged**; I'll bump `go.mod`/`go.sum` to the new tag as a follow-up commit.